### PR TITLE
37: Citation reference typo

### DIFF
--- a/file-disks/2.txt
+++ b/file-disks/2.txt
@@ -1,0 +1,3 @@
+page 15: "It remains a technical report (and not a published paper) because the authors were
+scooped by Seltzer et al. [S90]." -> "It remains a technical report (and not a published paper) because the authors were
+scooped by Seltzer et al. [SCO90]." (Patrick Lee @ UBC)


### PR DESCRIPTION
I think the reference to the Seltzer et al. paper should be changed to [SCO90] for consistency, unless the abbreviation to [S90] is a convention I am unaware of!