### PR TITLE
Typo in Dijkstra bio

### DIFF
--- a/threads-intro/1.txt
+++ b/threads-intro/1.txt
@@ -1,3 +1,5 @@
 while he was at the Technische Hochshule of Eindhoven (THE)
 ->
 while he was at the Technische Hogeschool of Eindhoven (THE)
+
+Felix Berief

--- a/threads-intro/1.txt
+++ b/threads-intro/1.txt
@@ -1,0 +1,3 @@
+while he was at the Technische Hochshule of Eindhoven (THE)
+->
+while he was at the Technische Hogeschool of Eindhoven (THE)

--- a/threads-intro/1.txt
+++ b/threads-intro/1.txt
@@ -1,5 +1,5 @@
 while he was at the Technische Hochshule of Eindhoven (THE)
 ->
-while he was at the Technische Hogeschool of Eindhoven (THE)
+while he was at the Technische Hogeschool Eindhoven (THE)
 
 Felix Berief


### PR DESCRIPTION
Hochshule (Hochschule) is the misspelled German name for university.
The official university name in Dutch was Technische Hogeschool Eindhoven ([https://en.wikipedia.org/wiki/THE_multiprogramming_system](https://en.wikipedia.org/wiki/THE_multiprogramming_system)).