### PR TITLE
16.2 Which Segment Are We Referring To?

### DIFF
--- a/vm-segmentation/1.txt
+++ b/vm-segmentation/1.txt
@@ -1,0 +1,18 @@
+# 16.2 Which Segment Are We Referring To?
+
+possible typo:
+SEG_MASK would be set to 0x3000
+
+correction:
+SEG_MASK would be set to 0x1000
+
+explanation:
+
+* The book sets up SEG_MASK to be 0x3000 ( 3*16^3 == 12288 )
+* The section is presumably referring to the same heap as in section 16.1
+* The heap starts at virtual address 4KB, 0x1000 ( 1*16^3 == 4096 )
+* Presumably this is the SEG_MASK we want to use?
+
+
+
+


### PR DESCRIPTION
Hi Remzi, 

great work on the book - really learning a lot from it. The code examples are also great! 
I think I might have possibly found a minor typo in section 16.2.

In the preceeding section 16.1 the book refers to the heap segment as beginning at 4KB. 

Assuming that section 16.2 tries to use the same values for the specific examples in the c code, the value for SEG_MASK should be set to the start of the heap. Book uses possibly incorrect value of 0x3000 (12288) for SEG_MASK. Heap starts at 0x1000 (4096) (4KB).

Cheers,
Adam 