### PR TITLE
wrong tense

### DIFF
--- a/file-intro/3.txt
+++ b/file-intro/3.txt
@@ -1,0 +1,2 @@
+"second, that the 64-bit offset be used" should be
+"second, that the 64-bit offset is used"


### PR DESCRIPTION
Grammatical error. The corrected tense is consistent with the "is" in the preceding part.

Chris Simionovici (University of Toronto)