### PR TITLE
Miliseconds instead of microseconds

### DIFF
--- a/cpu-sched/2.txt
+++ b/cpu-sched/2.txt
@@ -1,0 +1,1 @@
+In the footnotes, in "but context-switches still happen in the *millisecond* time range.", I think *milisecond* should be *microsecond*.


### PR DESCRIPTION
In the footnotes, in "but context-switches still happen in the *millisecond* time range.", I think *milisecond* should be *microsecond*.