### PR TITLE
`cpu-api`: missing a pair of parentheses

### DIFF
--- a/cpu-api/1.txt
+++ b/cpu-api/1.txt
@@ -1,0 +1,3 @@
+Version 1.01, Page 4, Footnote 3
+
+	execl -> execl()		# at the bottom of the page


### PR DESCRIPTION
> On Linux, there are six variants of exec(): execl, execlp(), execle(), execv(), execvp(), and execvpe(). Read the man pages to learn more.

I add a file to suggest adding a pair of parentheses after `execl` (-> `execl()`) to enjoy better consistency.