### PR TITLE
Fixed typo in citation C06 of threads-locks-usage, Fixed typo in vm-complete

### DIFF
--- a/threads-locks-usage/3.txt
+++ b/threads-locks-usage/3.txt
@@ -1,0 +1,3 @@
+[C06] [...] LWN has many wonderful articles about the latest in Linux This article is a short [...]
+-->
+[C06] [...] LWN has many wonderful articles about the latest in Linux. This article is a short [...]

--- a/vm-complete/1.txt
+++ b/vm-complete/1.txt
@@ -1,0 +1,3 @@
+"Even the code in main()..." --> "Even though the code in main...()"
+
+missing "though"


### PR DESCRIPTION
I think there was a missing period since there is a capitalized "t" in "This" in the middle of the sentence.